### PR TITLE
Add DevC Hanoi to DevCGlobalDirectory

### DIFF
--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -99,6 +99,20 @@
   - Github: https://github.com/devcjakarta
 </details>
 
+<details>
+  <summary>
+    <b>DevC Hanoi</b>
+  </summary>
+
+  - Lead(s):
+    - [Le Thanh Hung](https://www.facebook.com/lethanhhung028)
+    - [Tran Duy Linh](https://www.facebook.com/DuyLinhsl)
+    - [Le Hanh Quyen](https://www.facebook.com/quinlele18)
+  - Facebook Group: https://www.facebook.com/groups/DevCHanoi
+  - GitHub: https://github.com/DevCHanoi
+</details>
+
+
 ## India
 
 <details>

--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -105,9 +105,7 @@
   </summary>
 
   - Lead(s):
-    - [Le Thanh Hung](https://www.facebook.com/lethanhhung028)
-    - [Tran Duy Linh](https://www.facebook.com/DuyLinhsl)
-    - [Le Hanh Quyen](https://www.facebook.com/quinlele18)
+    - [Le Thanh Hung](https://github.com/hungle90)
   - Facebook Group: https://www.facebook.com/groups/DevCHanoi
   - GitHub: https://github.com/DevCHanoi
 </details>


### PR DESCRIPTION
## Summary
This pull request add missing developer circles in DevCGlobalDirectory #59 
This pull request add DevC Hanoi to DevCGlobalDirectory.md and the markdown file has been following the new design in #57 
This pull request follow the #68 and remove all the facebook links and change to github account