### PR TITLE
Add all DevC in Vietnam to DevCGlobalDirectory

### DIFF
--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -110,6 +110,15 @@
   - GitHub: https://github.com/DevCHanoi
 </details>
 
+<details>
+  <summary>
+    <b>DevC Ho Chi Minh City</b>
+  </summary>
+
+  - Lead(s):
+    - [Duong The Vinh](https://github.com/leovinh)
+  - Facebook Group: https://www.facebook.com/groups/DevCHoChiMinhCity/
+</details>
 
 ## India
 

--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -112,6 +112,16 @@
 
 <details>
   <summary>
+    <b>DevC Da Nang</b>
+  </summary>
+
+  - Lead(s):
+    - [Tran Hanh Trang](https://github.com/tranghanhtran)
+  - Facebook Group: https://www.facebook.com/groups/devcdanang/
+</details>
+
+<details>
+  <summary>
     <b>DevC Ho Chi Minh City</b>
   </summary>
 
@@ -119,6 +129,7 @@
     - [Duong The Vinh](https://github.com/leovinh)
   - Facebook Group: https://www.facebook.com/groups/DevCHoChiMinhCity/
 </details>
+
 
 ## India
 


### PR DESCRIPTION
# Add all DevC in Vietnam to DevCGlobalDirectory
### Summary
This pull request add missing developer circles in DevCGlobalDirectory #59 
This pull request add all DevC in Vietnam to DevCGlobalDirectory.md and the markdown file has been following the new design in #57 
This pull request follow the #68  and remove all the facebook links and change to github account

### DevC in Vietnam list:
- DevC Hanoi
- DevC Da Nang
- DevC Ho Chi Minh City