### PR TITLE
remove a same reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,7 @@
   </a>
 </p>
 
-<h3 align="center">
-  <a href="https://www.developercircleresources.com/learningPath/open-source">Getting Started</a>
-  <span> · </span>
+<h3 align="center">  
   <a href="https://www.developercircleresources.com/learningPath/open-source">Learn the Basics</a>
   <span> · </span>
   <a href="https://github.com/fbdevelopercircles/FbDevcCommunityContent/blob/master/CONTRIBUTING.md">Contribute</a>


### PR DESCRIPTION
#### What does this PR do?
Maybe we should remove a option because the options "Getting Started" and "Learn the Basics" has same reference to"https://www.developercircleresources.com/learningPath/open-source".
