### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Useful articles and learning resources.
 <br />
 
 - [Wisdom Geek](https://www.wisdomgeek.com) - Web development and data science related posts
-- [https://bolajiayodeji.com/](https://www.bolajiayodeji.com) - Web development, JavaScript and JAMstack related posts
+- [https://bolajiayodeji.com/](https://bolajiayodeji.com) - Web development, JavaScript and JAMstack related posts
 - [Free Code Camp](https://www.freecodecamp.org) - Software development related posts
 - [CSS Tricks](https://css-tricks.com) - CSS related posts
 - [DEV.to](https://dev.to) - The All in One Blogs Portal for Developers


### PR DESCRIPTION
#168  **Fixes Broken Link** 
the link on README.md, under "Blogs",
It should be `https://bolajiayodeji.com/ ` instead of `https://www.bolajiayodeji.com/ ` without `www`