### PR TITLE
Add DevC Boston lead info

### DIFF
--- a/DevCGlobalDirectory.md
+++ b/DevCGlobalDirectory.md
@@ -44,6 +44,20 @@
   - Github: https://github.com/DevC-Kingston
 </details>
 
+<details>
+  <summary>
+    <b>DevC Boston</b>
+  </summary>
+
+  - Lead(s):
+    - [Henry Saniuk](https://github.com/speakerbug)
+    - [Jackie McGraw](https://github.com/JacquelineDMcGraw)
+    - [Courtney Clay](https://github.com/courtneyclayart)
+    - [Jessica Lindsay](https://github.com/jesslindz)
+  - Facebook Group: https://www.facebook.com/groups/DevCBoston
+  - GitHub: https://github.com/Boston-DevC
+</details>
+
 
 ## APAC (Asia Pacific)
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds the lead and group information for Boston DevC.
